### PR TITLE
Pass pool options off to connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Adds configurable connection pools per host for persistent http connections
 
 ## Status
 
-**Prototype**
+**Alpha**
+
+All testing for this gem is currently in the form of bench testing.  We're evaulating this gem in our production stack.
 
 ## Installation
 
@@ -24,7 +26,16 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+In an initializer:
+
+```ruby
+Excon.defaults[:tcp_nodelay] = true
+Faraday.default_adapter = :persistent_excon
+FaradayPersistentExcon.connection_pools = {
+  'https://search.example.com' => { size: 5 },
+  'http://localhost:9200' => { size: 10, timeout: 2 }
+}
+```
 
 ## Development
 

--- a/lib/faraday_persistent_excon.rb
+++ b/lib/faraday_persistent_excon.rb
@@ -19,7 +19,7 @@ module FaradayPersistentExcon
 
   self.excon_options = {}
   self.perform_request_class = FaradayPersistentExcon::PerformRequest
-  self.connection_pools = []
+  self.connection_pools = {}
 end
 
 Faraday::Adapter.register_middleware persistent_excon: ->{ FaradayPersistentExcon::Adapter }

--- a/lib/faraday_persistent_excon/connection_pools.rb
+++ b/lib/faraday_persistent_excon/connection_pools.rb
@@ -26,14 +26,12 @@ module FaradayPersistentExcon
       end
 
       def connection_pool_for(url)
-        config = FaradayPersistentExcon.connection_pools.find do |hsh|
-          hsh[:url] == url
-        end
+        config = FaradayPersistentExcon.connection_pools[url]
 
         if config
           self.__pools.fetch_or_store(url) do
-            ::ConnectionPool.new(size: config[:size]) do
-              ::Excon.new(config[:url], persistent: true, thread_safe_sockets: false)
+            ::ConnectionPool.new(config) do
+              ::Excon.new(url, persistent: true, thread_safe_sockets: false)
             end
           end
         end


### PR DESCRIPTION
Changing the interface from an array of hashes which needs an iterative search for each request to a hash of hashes.  This also allows us to pass options to `connection_pool`.
