### PR TITLE
Add idle timeout for persistent connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Excon.defaults[:tcp_nodelay] = true
 Faraday.default_adapter = :persistent_excon
 FaradayPersistentExcon.connection_pools = {
   'https://search.example.com' => { size: 5 },
-  'http://localhost:9200' => { size: 10, timeout: 2 }
+  'http://localhost:9200' => { size: 10, timeout: 2, idle_timeout: 300 }
 }
 ```
 

--- a/lib/faraday_persistent_excon.rb
+++ b/lib/faraday_persistent_excon.rb
@@ -9,6 +9,7 @@ require 'faraday_persistent_excon/perform_request'
 require 'faraday_persistent_excon/adapter'
 require 'faraday_persistent_excon/request_options'
 require 'faraday_persistent_excon/connection_pools'
+require 'faraday_persistent_excon/connection'
 
 module FaradayPersistentExcon
   class << self
@@ -17,6 +18,7 @@ module FaradayPersistentExcon
     attr_accessor :connection_pools
     attr_accessor :idempotent_methods
     attr_accessor :retry_idempotent_methods
+    attr_accessor :idle_timeout
   end
 
   self.excon_options = {}
@@ -24,6 +26,7 @@ module FaradayPersistentExcon
   self.connection_pools = {}
   self.idempotent_methods = %w[GET HEAD PUT DELETE OPTIONS TRACE]
   self.retry_idempotent_methods = true
+  self.idle_timeout = 60
 end
 
 Faraday::Adapter.register_middleware persistent_excon: ->{ FaradayPersistentExcon::Adapter }

--- a/lib/faraday_persistent_excon/connection.rb
+++ b/lib/faraday_persistent_excon/connection.rb
@@ -1,0 +1,26 @@
+module FaradayPersistentExcon
+  class Connection
+    attr_accessor :excon
+    attr_accessor :last_use
+    attr_accessor :idle_timeout
+
+    def initialize(excon:, idle_timeout:)
+      @excon = excon
+      @idle_timeout = idle_timeout
+    end
+
+    def reset
+      excon.reset
+    end
+
+    def expired?
+      return false if last_use.nil?
+
+      Time.now.utc - last_use > idle_timeout
+    end
+
+    def used!
+      self.last_use = Time.now.utc
+    end
+  end
+end


### PR DESCRIPTION
This gives us the ability to transparently reset connections that our load balancer is going to terminate by setting the `idle_timeout` to something lower than the LB's idle timeout.
