### PR TITLE
Stop using old faraday errors; include reason_phrase

### DIFF
--- a/faraday_persistent_excon.gemspec
+++ b/faraday_persistent_excon.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday"
+  spec.add_dependency "faraday", ">= 0.10.0"
   spec.add_dependency "excon"
   spec.add_dependency "connection_pool"
   spec.add_dependency "activesupport"

--- a/faraday_persistent_excon.gemspec
+++ b/faraday_persistent_excon.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thread_safe"
 
   spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec"
 end

--- a/faraday_persistent_excon.gemspec
+++ b/faraday_persistent_excon.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "thread_safe"
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec"
 end

--- a/lib/faraday_persistent_excon/adapter.rb
+++ b/lib/faraday_persistent_excon/adapter.rb
@@ -12,7 +12,13 @@ module FaradayPersistentExcon
 
     def perform_request(env)
       response = FaradayPersistentExcon.perform_request_class.new.call env
-      save_response(env, response.status.to_i, response.body, response.headers)
+      save_response(
+        env,
+        response.status.to_i,
+        response.body,
+        response.headers,
+        response.reason_phrase
+      )
     end
   end
 end

--- a/lib/faraday_persistent_excon/perform_request.rb
+++ b/lib/faraday_persistent_excon/perform_request.rb
@@ -11,15 +11,16 @@ module FaradayPersistentExcon
       end
 
     rescue ::Excon::Errors::SocketError => err
-      if err.message =~ /\btimeout\b/
-        raise Faraday::Error::TimeoutError, err
-      elsif err.message =~ /\bcertificate\b/
-        raise Faraday::Error::SSLError, err
+      case err.message
+      when /\btimeout\b/
+        raise Faraday::TimeoutError, err
+      when /\bcertificate\b/
+        raise Faraday::SSLError, err
       else
-        raise Faraday::Error::ConnectionFailed, err
+        raise Faraday::ConnectionFailed, err
       end
     rescue ::Excon::Errors::Timeout => err
-      raise Faraday::Error::TimeoutError, err
+      raise Faraday::TimeoutError, err
     end
 
     protected

--- a/lib/faraday_persistent_excon/version.rb
+++ b/lib/faraday_persistent_excon/version.rb
@@ -1,3 +1,3 @@
 module FaradayPersistentExcon
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
This was a pass to support faraday 1.x

`reason_phrase` was added in https://github.com/lostisland/faraday/pull/547